### PR TITLE
Implemented emoji counter to fix #35

### DIFF
--- a/lib/message/parser/emotes.spec.ts
+++ b/lib/message/parser/emotes.spec.ts
@@ -78,5 +78,32 @@ describe("./message/parser/emotes", function () {
         "End index 5 is out of range for given message string"
       );
     });
+
+    it("should parse single emote if preceeded by emoji", function () {
+      assert.deepStrictEqual(parseEmotes("👉 <3", "445:2-3"), [
+        new TwitchEmote("445", 3, 5, "<3"),
+      ]);
+    });
+
+    it("should parse multiple instances of the same emote if preceeded by emoji", function () {
+      assert.deepStrictEqual(parseEmotes("👉 <3 👉 <3", "445:2-3,7-8"), [
+        new TwitchEmote("445", 3, 5, "<3"),
+        new TwitchEmote("445", 9, 11, "<3"),
+      ]);
+    });
+
+    it("should parse multiple emotes in the same message when multiple emojis exist between them", function () {
+      assert.deepStrictEqual(
+        parseEmotes(
+          "🌚 Kappa 🌚 🐈 Keepo 🐈 🎨 KappaRoss 🎨",
+          "25:2-6/1902:12-16/70433:22-30"
+        ),
+        [
+          new TwitchEmote("25", 3, 8, "Kappa"),
+          new TwitchEmote("1902", 15, 20, "Keepo"),
+          new TwitchEmote("70433", 27, 36, "KappaRoss"),
+        ]
+      );
+    });
   });
 });

--- a/lib/message/parser/emotes.ts
+++ b/lib/message/parser/emotes.ts
@@ -21,7 +21,7 @@ export function parseEmotes(
   const matchedEmojis = [...messageText.matchAll(regex)];
   for (let index = 0; index < matchedEmojis.length; index++) {
     const emoji = matchedEmojis[index];
-    if (emoji !== null && emoji.index !== undefined) {
+    if (emoji.index !== undefined) {
       emojis.push(emoji.index);
     }
   }

--- a/lib/message/parser/emotes.ts
+++ b/lib/message/parser/emotes.ts
@@ -25,7 +25,6 @@ export function parseEmotes(
 
   for (const emoteInstancesSrc of emotesSrc.split("/")) {
     const [emoteID, instancesSrc] = emoteInstancesSrc.split(":", 2);
-    let emojiCount = 0;
     for (const instanceSrc of instancesSrc.split(",")) {
       let [startIndex, endIndexInclusive] = instanceSrc
         .split("-")
@@ -37,16 +36,16 @@ export function parseEmotes(
       }
 
       // Fix for when emojis exist before this emote.
-      emojiCount = emojiIndexes.filter(
-        (emojiIndex) =>
-          emojiIndex <= startIndex + (emojiCount > 0 ? emojiCount - 1 : 0)
-      ).length;
+      const emojiCount = emojiIndexes.reduce((acc, emojiIndex) => {
+        const addOne = emojiIndex <= startIndex + acc;
+        return addOne ? acc + 1 : acc;
+      }, 0);
       startIndex += emojiCount;
       endIndexInclusive += emojiCount;
 
       // to make endIndex exclusive
       const endIndex = endIndexInclusive + 1;
-      if (endIndex > messageText.length) {
+      if (endIndex > (messageText.length + emojiCount)) {
         throw new ParseError(
           `End index ${endIndexInclusive} is out of range for given message string`
         );

--- a/lib/message/parser/emotes.ts
+++ b/lib/message/parser/emotes.ts
@@ -13,17 +13,14 @@ export function parseEmotes(
     return emotes;
   }
 
-  // Gets emojis in text
-  const emojis = [];
-
   // Lodash library regexp for matching emojis.
   const regex = /(?:[\u2700-\u27bf]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff])[\ufe0e\ufe0f]?(?:[\u0300-\u036f\ufe20-\ufe23\u20d0-\u20f0]|\ud83c[\udffb-\udfff])?(?:\u200d(?:[^\ud800-\udfff]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff])[\ufe0e\ufe0f]?(?:[\u0300-\u036f\ufe20-\ufe23\u20d0-\u20f0]|\ud83c[\udffb-\udfff])?)*/g;
-  const matchedEmojis = [...messageText.matchAll(regex)];
-  for (let index = 0; index < matchedEmojis.length; index++) {
-    const emoji = matchedEmojis[index];
-    if (emoji.index !== undefined) {
-      emojis.push(emoji.index);
-    }
+
+  const emojiIndexes = [];
+
+  let m;
+  while ((m = regex.exec(messageText))) {
+    emojiIndexes.push(m.index);
   }
 
   for (const emoteInstancesSrc of emotesSrc.split("/")) {
@@ -40,7 +37,7 @@ export function parseEmotes(
       }
 
       // Fix for when emojis exist before this emote.
-      emojiCount = emojis.filter(
+      emojiCount = emojiIndexes.filter(
         (emojiIndex) =>
           emojiIndex <= startIndex + (emojiCount > 0 ? emojiCount - 1 : 0)
       ).length;

--- a/lib/message/parser/emotes.ts
+++ b/lib/message/parser/emotes.ts
@@ -45,7 +45,7 @@ export function parseEmotes(
 
       // to make endIndex exclusive
       const endIndex = endIndexInclusive + 1;
-      if (endIndex > (messageText.length + emojiCount)) {
+      if (endIndex > messageText.length + emojiCount) {
         throw new ParseError(
           `End index ${endIndexInclusive} is out of range for given message string`
         );

--- a/lib/message/parser/emotes.ts
+++ b/lib/message/parser/emotes.ts
@@ -13,10 +13,24 @@ export function parseEmotes(
     return emotes;
   }
 
+  // Gets emojis in text
+  const emojis = [];
+
+  // Lodash library regexp for matching emojis.
+  const regex = /(?:[\u2700-\u27bf]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff])[\ufe0e\ufe0f]?(?:[\u0300-\u036f\ufe20-\ufe23\u20d0-\u20f0]|\ud83c[\udffb-\udfff])?(?:\u200d(?:[^\ud800-\udfff]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff])[\ufe0e\ufe0f]?(?:[\u0300-\u036f\ufe20-\ufe23\u20d0-\u20f0]|\ud83c[\udffb-\udfff])?)*/g;
+  const matchedEmojis = [...messageText.matchAll(regex)];
+  for (let index = 0; index < matchedEmojis.length; index++) {
+    const emoji = matchedEmojis[index];
+    if (emoji !== null && emoji.index !== undefined) {
+      emojis.push(emoji.index);
+    }
+  }
+
   for (const emoteInstancesSrc of emotesSrc.split("/")) {
     const [emoteID, instancesSrc] = emoteInstancesSrc.split(":", 2);
+    let emojiCount = 0
     for (const instanceSrc of instancesSrc.split(",")) {
-      const [startIndex, endIndexInclusive] = instanceSrc
+      let [startIndex, endIndexInclusive] = instanceSrc
         .split("-")
         .map(parseIntThrowing);
       if (endIndexInclusive == null) {
@@ -24,6 +38,11 @@ export function parseEmotes(
           `No - found in emote index range "${instanceSrc}"`
         );
       }
+
+      // Fix for when emojis exist before this emote.
+      emojiCount = emojis.filter(emojiIndex => emojiIndex <= (startIndex + (emojiCount > 0 ? emojiCount - 1 : 0))).length;
+      startIndex += emojiCount;
+      endIndexInclusive += emojiCount;
 
       // to make endIndex exclusive
       const endIndex = endIndexInclusive + 1;

--- a/lib/message/parser/emotes.ts
+++ b/lib/message/parser/emotes.ts
@@ -28,7 +28,7 @@ export function parseEmotes(
 
   for (const emoteInstancesSrc of emotesSrc.split("/")) {
     const [emoteID, instancesSrc] = emoteInstancesSrc.split(":", 2);
-    let emojiCount = 0
+    let emojiCount = 0;
     for (const instanceSrc of instancesSrc.split(",")) {
       let [startIndex, endIndexInclusive] = instanceSrc
         .split("-")
@@ -40,7 +40,10 @@ export function parseEmotes(
       }
 
       // Fix for when emojis exist before this emote.
-      emojiCount = emojis.filter(emojiIndex => emojiIndex <= (startIndex + (emojiCount > 0 ? emojiCount - 1 : 0))).length;
+      emojiCount = emojis.filter(
+        (emojiIndex) =>
+          emojiIndex <= startIndex + (emojiCount > 0 ? emojiCount - 1 : 0)
+      ).length;
       startIndex += emojiCount;
       endIndexInclusive += emojiCount;
 


### PR DESCRIPTION
Twitch interprets emojis as 1 character, while Javascript interprets emojis as 2 characters.

This pull request takes that into consideration and patches the retrieved `startIndex` &  `endIndex` values by first matching emojis, using a regexp from lodash, and then appending their `startIndex`es into an array. The rest is self-explanatory, I hope.

I think this is a major semver change, because it breaks user implementations of `msg.emotes[].code` & `msg.emotes[].startIndex` & `msg.emotes[].endIndex`.

Make sure to squash this commit WAYTOODANK.