### PR TITLE
Implement undocumented Twitch IRC tag "flags"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Minor: Added `flags` and `flagsRaw` properties to `PrivmsgMessage` and `UsernoticeMessage` objects, allowing inspection of AutoMod message rating results. (#38)
 - Bugfix: Emotes occurring after emojis are now correctly parsed (#35)
 
 ## v3.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Minor: Added `flags` and `flagsRaw` properties to `PrivmsgMessage` and `UsernoticeMessage` objects, allowing inspection of AutoMod message rating results. (#38)
+- Minor: Added `flags` and `flagsRaw` properties to `PrivmsgMessage` and `UsernoticeMessage` classes, allowing inspection of AutoMod message rating results. (#38)
 - Bugfix: Emotes occurring after emojis are now correctly parsed (#35)
 
 ## v3.3.0

--- a/lib/message/flag.ts
+++ b/lib/message/flag.ts
@@ -19,7 +19,7 @@ export class TwitchFlag {
   public endIndex: number;
 
   /**
-   * The part of the original message string that was recognizes as flagged, e.g. "stfu".
+   * The part of the original message string that was recognized as flagged, e.g. "stfu".
    */
   public word: string;
 

--- a/lib/message/flag.ts
+++ b/lib/message/flag.ts
@@ -1,5 +1,7 @@
 /**
  * Single instance of a twitch automod flagged word in a message string.
+ *
+ * **Note:** This is an undocumented Twitch IRC feature and may change at any time, use at your own risk.
  */
 export class TwitchFlag {
   /**
@@ -24,8 +26,6 @@ export class TwitchFlag {
   public word: string;
 
   /**
-   * **Note:** This is an undocumented Twitch IRC feature, use at your own risk.
-   *
    * Flag category, as per the AutoMod moderation categories:
    * * **I:** Identity language - Words referring to race, religion, gender,
    * orientation, disability, or similar. Hate speech falls under this category.

--- a/lib/message/flag.ts
+++ b/lib/message/flag.ts
@@ -1,0 +1,55 @@
+/**
+ * Single instance of a twitch automod flagged word in a message string.
+ */
+export class TwitchFlag {
+  /**
+   * inclusive start index in the original message text.
+   * Note that we count unicode code points, not bytes with this.
+   * If you use this, make sure your code splits or indexes strings by their
+   * unicode code points, and not their bytes.
+   */
+  public startIndex: number;
+
+  /**
+   * exclusive end index in the original message text.
+   * Note that we count unicode code points, not bytes with this.
+   * If you use this, make sure your code splits or indexes strings by their
+   * unicode code points, and not their bytes.
+   */
+  public endIndex: number;
+
+  /**
+   * The part of the original message string that was recognizes as flagged, e.g. "stfu".
+   */
+  public word: string;
+
+  /**
+   * **Note:** This is an undocumented Twitch IRC feature, use at your own risk.
+   *
+   * Flag category, as per the AutoMod moderation categories:
+   * * **I:** Identity language - Words referring to race, religion, gender,
+   * orientation, disability, or similar. Hate speech falls under this category.
+   * * **S:** Sexually explicit language - Words or phrases referring to
+   * sexual acts, sexual content, and body parts.
+   * * **A:** Aggressive language - Hostility towards other people, often
+   * associated with bullying.
+   * * **P:** Profanity - Expletives, curse words, and vulgarity. This
+   * filter especially helps those who wish to keep their community family-friendly.
+   *
+   * If this array is empty, this means that Twitch flagged it for a
+   * non-specified reason.
+   */
+  public categories: Array<{ category: string; score: number }>;
+
+  public constructor(
+    startIndex: number,
+    endIndex: number,
+    text: string,
+    category: Array<{ category: string; score: number }>
+  ) {
+    this.startIndex = startIndex;
+    this.endIndex = endIndex;
+    this.word = text;
+    this.categories = category;
+  }
+}

--- a/lib/message/flags.ts
+++ b/lib/message/flags.ts
@@ -1,0 +1,3 @@
+import { TwitchFlag } from "./flag";
+
+export type TwitchFlagList = TwitchFlag[];

--- a/lib/message/parser/flags.spec.ts
+++ b/lib/message/parser/flags.spec.ts
@@ -10,31 +10,31 @@ describe("./message/parser/flags", function () {
       assert.deepStrictEqual(parseFlags("", ""), []);
     });
 
-    it("should parse single flag, I category", function () {
+    it("should parse single flag, with one I category", function () {
       assert.deepStrictEqual(parseFlags("retard streamer", "0-5:I.3"), [
         new TwitchFlag(0, 6, "retard", [{ category: "I", score: 3 }]),
       ]);
     });
 
-    it("should parse single flag, S category", function () {
+    it("should parse single flag, with one S category", function () {
       assert.deepStrictEqual(parseFlags("a phallic object", "2-8:S.7"), [
         new TwitchFlag(2, 9, "phallic", [{ category: "S", score: 7 }]),
       ]);
     });
 
-    it("should parse single flag, A category", function () {
+    it("should parse single flag, with one A category", function () {
       assert.deepStrictEqual(parseFlags("you kill", "4-7:A.7"), [
         new TwitchFlag(4, 8, "kill", [{ category: "A", score: 7 }]),
       ]);
     });
 
-    it("should parse single flag, P category", function () {
+    it("should parse single flag, with one P category", function () {
       assert.deepStrictEqual(parseFlags("stfu", "0-3:P.6"), [
         new TwitchFlag(0, 4, "stfu", [{ category: "P", score: 6 }]),
       ]);
     });
 
-    it("should parse multiple instances of the same flag, P category", function () {
+    it("should parse multiple instances of the same flag, with one P category", function () {
       assert.deepStrictEqual(
         parseFlags("shit in my asshole", "0-3:P.6,11-17:P.6"),
         [

--- a/lib/message/parser/flags.spec.ts
+++ b/lib/message/parser/flags.spec.ts
@@ -120,5 +120,11 @@ describe("./message/parser/flags", function () {
         ]
       );
     });
+
+    it.only("should parse single flag, but with empty categories", function () {
+      assert.deepStrictEqual(parseFlags("$test xanax", "6-10:"), [
+        new TwitchFlag(6, 11, "xanax", []),
+      ]);
+    });
   });
 });

--- a/lib/message/parser/flags.spec.ts
+++ b/lib/message/parser/flags.spec.ts
@@ -59,46 +59,6 @@ describe("./message/parser/flags", function () {
       );
     });
 
-    it("should throw a ParseError if flag index range has no dash", function () {
-      assertThrowsChain(
-        () => parseFlags("", "3:P.7"),
-        ParseError,
-        'No - found in flag index range "3"'
-      );
-    });
-
-    it("should throw a ParseError if the from index is not a valid integer", function () {
-      assertThrowsChain(
-        () => parseFlags("", "abc-3:P.7"),
-        ParseError,
-        'Invalid integer for string "abc"'
-      );
-    });
-
-    it("should throw a ParseError if the to index is not a valid integer", function () {
-      assertThrowsChain(
-        () => parseFlags("", "0-abc:P.7"),
-        ParseError,
-        'Invalid integer for string "abc"'
-      );
-    });
-
-    it("should throw a ParseError if a end index is out of range", function () {
-      assertThrowsChain(
-        () => parseFlags("stfu", "0-4:P.6"),
-        ParseError,
-        "End index 4 is out of range for given message string"
-      );
-    });
-
-    it("should throw a ParseError if category's score is a string", function () {
-      assertThrowsChain(
-        () => parseFlags("stfu", "0-3:P.abc"),
-        ParseError,
-        'Invalid integer for string "abc"'
-      );
-    });
-
     it("should parse four flags, with multiple categories", function () {
       assert.deepStrictEqual(
         parseFlags(
@@ -125,6 +85,38 @@ describe("./message/parser/flags", function () {
       assert.deepStrictEqual(parseFlags("$test xanax", "6-10:"), [
         new TwitchFlag(6, 11, "xanax", []),
       ]);
+    });
+
+    it("should throw a ParseError if a end index is out of range", function () {
+      assertThrowsChain(
+        () => parseFlags("stfu", "0-4:P.6"),
+        ParseError,
+        "End index 4 is out of range for given message string"
+      );
+    });
+
+    it("should parse normal string with no flags, as no flags", function () {
+      assert.deepStrictEqual(parseFlags("Kappa Keepo KappaRoss", ""), []);
+    });
+
+    it("should parse no flag if the category's score is a string", function () {
+      assert.deepStrictEqual(parseFlags("stfu", "0-3:P.abc"), []);
+    });
+
+    it("should parse no flag if the flag index range has no dash", function () {
+      assert.deepStrictEqual(parseFlags("", "3:P.7"), []);
+    });
+
+    it("should parse no flag if the from index is not a valid integer", function () {
+      assert.deepStrictEqual(parseFlags("", "abc-3:P.7"), []);
+    });
+
+    it("should parse no flag if the to index is not a valid integer", function () {
+      assert.deepStrictEqual(parseFlags("", "0-abc:P.7"), []);
+    });
+
+    it("should parse no flag, in case Twitch changes the functionality", function () {
+      assert.deepStrictEqual(parseFlags("stfu", "0-3=PRO.100%"), []);
     });
   });
 });

--- a/lib/message/parser/flags.spec.ts
+++ b/lib/message/parser/flags.spec.ts
@@ -121,7 +121,7 @@ describe("./message/parser/flags", function () {
       );
     });
 
-    it.only("should parse single flag, but with empty categories", function () {
+    it("should parse single flag, but with empty categories", function () {
       assert.deepStrictEqual(parseFlags("$test xanax", "6-10:"), [
         new TwitchFlag(6, 11, "xanax", []),
       ]);

--- a/lib/message/parser/flags.spec.ts
+++ b/lib/message/parser/flags.spec.ts
@@ -1,0 +1,124 @@
+import { assert } from "chai";
+import { assertThrowsChain } from "../../helpers.spec";
+import { TwitchFlag } from "../flag";
+import { parseFlags } from "./flags";
+import { ParseError } from "./parse-error";
+
+describe("./message/parser/flags", function () {
+  describe("#parseFlags()", function () {
+    it("should parse empty string as no flags", function () {
+      assert.deepStrictEqual(parseFlags("", ""), []);
+    });
+
+    it("should parse single flag, I category", function () {
+      assert.deepStrictEqual(parseFlags("retard streamer", "0-5:I.3"), [
+        new TwitchFlag(0, 6, "retard", [{ category: "I", score: 3 }]),
+      ]);
+    });
+
+    it("should parse single flag, S category", function () {
+      assert.deepStrictEqual(parseFlags("a phallic object", "2-8:S.7"), [
+        new TwitchFlag(2, 9, "phallic", [{ category: "S", score: 7 }]),
+      ]);
+    });
+
+    it("should parse single flag, A category", function () {
+      assert.deepStrictEqual(parseFlags("you kill", "4-7:A.7"), [
+        new TwitchFlag(4, 8, "kill", [{ category: "A", score: 7 }]),
+      ]);
+    });
+
+    it("should parse single flag, P category", function () {
+      assert.deepStrictEqual(parseFlags("stfu", "0-3:P.6"), [
+        new TwitchFlag(0, 4, "stfu", [{ category: "P", score: 6 }]),
+      ]);
+    });
+
+    it("should parse multiple instances of the same flag, P category", function () {
+      assert.deepStrictEqual(
+        parseFlags("shit in my asshole", "0-3:P.6,11-17:P.6"),
+        [
+          new TwitchFlag(0, 4, "shit", [{ category: "P", score: 6 }]),
+          new TwitchFlag(11, 18, "asshole", [{ category: "P", score: 6 }]),
+        ]
+      );
+    });
+
+    it("should sort results by start index", function () {
+      assert.deepStrictEqual(
+        parseFlags(
+          "shit in my asshole fucking shit mechanics",
+          "0-3:P.7,11-17:P.7,19-25:P.7,27-30:P.7"
+        ),
+        [
+          new TwitchFlag(0, 4, "shit", [{ category: "P", score: 7 }]),
+          new TwitchFlag(11, 18, "asshole", [{ category: "P", score: 7 }]),
+          new TwitchFlag(19, 26, "fucking", [{ category: "P", score: 7 }]),
+          new TwitchFlag(27, 31, "shit", [{ category: "P", score: 7 }]),
+        ]
+      );
+    });
+
+    it("should throw a ParseError if flag index range has no dash", function () {
+      assertThrowsChain(
+        () => parseFlags("", "3:P.7"),
+        ParseError,
+        'No - found in flag index range "3"'
+      );
+    });
+
+    it("should throw a ParseError if the from index is not a valid integer", function () {
+      assertThrowsChain(
+        () => parseFlags("", "abc-3:P.7"),
+        ParseError,
+        'Invalid integer for string "abc"'
+      );
+    });
+
+    it("should throw a ParseError if the to index is not a valid integer", function () {
+      assertThrowsChain(
+        () => parseFlags("", "0-abc:P.7"),
+        ParseError,
+        'Invalid integer for string "abc"'
+      );
+    });
+
+    it("should throw a ParseError if a end index is out of range", function () {
+      assertThrowsChain(
+        () => parseFlags("stfu", "0-4:P.6"),
+        ParseError,
+        "End index 4 is out of range for given message string"
+      );
+    });
+
+    it("should throw a ParseError if category's score is a string", function () {
+      assertThrowsChain(
+        () => parseFlags("stfu", "0-3:P.abc"),
+        ParseError,
+        'Invalid integer for string "abc"'
+      );
+    });
+
+    it("should parse four flags, with multiple categories", function () {
+      assert.deepStrictEqual(
+        parseFlags(
+          "shut the fuck up retard streamer you kill a phallic object",
+          "0-15:A.7/I.6/P.6,17-22:A.7/I.6,37-40:A.7,44-50:S.7"
+        ),
+        [
+          new TwitchFlag(0, 16, "shut the fuck up", [
+            { category: "A", score: 7 },
+            { category: "I", score: 6 },
+            { category: "P", score: 6 },
+          ]),
+          new TwitchFlag(17, 23, "retard", [
+            { category: "A", score: 7 },
+            { category: "I", score: 6 },
+          ]),
+          new TwitchFlag(37, 41, "kill", [{ category: "A", score: 7 }]),
+          new TwitchFlag(44, 51, "phallic", [{ category: "S", score: 7 }]),
+        ]
+      );
+    });
+  });
+});

--- a/lib/message/parser/flags.ts
+++ b/lib/message/parser/flags.ts
@@ -1,6 +1,5 @@
 import { TwitchFlag } from "../flag";
 import { TwitchFlagList } from "../flags";
-import { parseIntThrowing } from "./common";
 import { ParseError } from "./parse-error";
 
 export function parseFlags(
@@ -9,7 +8,11 @@ export function parseFlags(
 ): TwitchFlagList {
   const flags: TwitchFlagList = [];
 
-  if (flagsSrc.length <= 0) {
+  const regex = /^((?:[0-9]+-[0-9]+:)(?:(?:[ISAP]\.[0-9]+\/?)+,?)?)+$/g;
+
+  const matchFlagsSrc = flagsSrc.match(regex);
+
+  if (flagsSrc.length <= 0 || matchFlagsSrc === null) {
     return flags;
   }
 
@@ -20,10 +23,7 @@ export function parseFlags(
 
     const [startIndex, endIndexInclusive] = indexes
       .split("-")
-      .map(parseIntThrowing);
-    if (endIndexInclusive == null) {
-      throw new ParseError(`No - found in flag index range "${indexes}"`);
-    }
+      .map((s) => Number(s));
 
     // to make endIndex exclusive
     const endIndex = endIndexInclusive + 1;
@@ -41,7 +41,7 @@ export function parseFlags(
         const [category, score] = instanceSrc.split(".");
         categories.push({
           category,
-          score: parseIntThrowing(score),
+          score: Number(score),
         });
       }
     }

--- a/lib/message/parser/flags.ts
+++ b/lib/message/parser/flags.ts
@@ -37,11 +37,13 @@ export function parseFlags(
 
     const categories: TwitchFlag["categories"] = [];
     for (const instanceSrc of instancesSrc.split("/")) {
-      const [category, score] = instanceSrc.split(".");
-      categories.push({
-        category,
-        score: parseIntThrowing(score),
-      });
+      if (instanceSrc.length > 0) {
+        const [category, score] = instanceSrc.split(".");
+        categories.push({
+          category,
+          score: parseIntThrowing(score),
+        });
+      }
     }
 
     flags.push(new TwitchFlag(startIndex, endIndex, flagText, categories));

--- a/lib/message/parser/flags.ts
+++ b/lib/message/parser/flags.ts
@@ -1,0 +1,54 @@
+import { TwitchFlag } from "../flag";
+import { TwitchFlagList } from "../flags";
+import { parseIntThrowing } from "./common";
+import { ParseError } from "./parse-error";
+
+export function parseFlags(
+  messageText: string,
+  flagsSrc: string
+): TwitchFlagList {
+  const flags: TwitchFlagList = [];
+
+  if (flagsSrc.length <= 0) {
+    return flags;
+  }
+
+  const messageCharacters = [...messageText];
+
+  for (const flagInstancesSrc of flagsSrc.split(",")) {
+    const [indexes, instancesSrc] = flagInstancesSrc.split(":", 2);
+
+    const [startIndex, endIndexInclusive] = indexes
+      .split("-")
+      .map(parseIntThrowing);
+    if (endIndexInclusive == null) {
+      throw new ParseError(`No - found in flag index range "${indexes}"`);
+    }
+
+    // to make endIndex exclusive
+    const endIndex = endIndexInclusive + 1;
+    if (endIndex > messageCharacters.length) {
+      throw new ParseError(
+        `End index ${endIndexInclusive} is out of range for given message string`
+      );
+    }
+
+    const flagText = messageCharacters.slice(startIndex, endIndex).join("");
+
+    const categories: TwitchFlag["categories"] = [];
+    for (const instanceSrc of instancesSrc.split("/")) {
+      const [category, score] = instanceSrc.split(".");
+      categories.push({
+        category,
+        score: parseIntThrowing(score),
+      });
+    }
+
+    flags.push(new TwitchFlag(startIndex, endIndex, flagText, categories));
+  }
+
+  // sort by start index
+  flags.sort((a, b) => a.startIndex - b.startIndex);
+
+  return flags;
+}

--- a/lib/message/parser/tag-values.ts
+++ b/lib/message/parser/tag-values.ts
@@ -1,11 +1,13 @@
 import { TwitchBadgesList } from "../badges";
 import { Color } from "../color";
 import { TwitchEmoteList } from "../emotes";
+import { TwitchFlagList } from "../flags";
 import { IRCMessageTags } from "../irc/tags";
 import { parseBadges } from "./badges";
 import { parseColor } from "./color";
 import { parseEmoteSets, TwitchEmoteSets } from "./emote-sets";
 import { parseEmotes } from "./emotes";
+import { parseFlags } from "./flags";
 import { MissingTagError } from "./missing-tag-error";
 import { ParseError } from "./parse-error";
 
@@ -82,6 +84,13 @@ export function convertToEmoteSets(value: string): TwitchEmoteSets {
   return parseEmoteSets(value);
 }
 
+export function convertToFlags(
+  value: string,
+  messageText: string
+): TwitchFlagList {
+  return parseFlags(messageText, value);
+}
+
 export interface TagValueParser {
   getString(key: string): string | undefined;
   requireString(key: string): string;
@@ -99,6 +108,8 @@ export interface TagValueParser {
   requireEmotes(key: string, messageText: string): TwitchEmoteList;
   getEmoteSets(key: string): TwitchEmoteSets | undefined;
   requireEmoteSets(key: string): TwitchEmoteSets;
+  getFlags(key: string, messageText: string): TwitchFlagList | undefined;
+  requireFlags(key: string, messageText: string): TwitchFlagList;
 }
 
 export function tagParserFor(ircTags: IRCMessageTags): TagValueParser {
@@ -124,5 +135,9 @@ export function tagParserFor(ircTags: IRCMessageTags): TagValueParser {
     getEmoteSets: (key: string) => getData(ircTags, key, convertToEmoteSets),
     requireEmoteSets: (key: string) =>
       requireData(ircTags, key, convertToEmoteSets),
+    getFlags: (key: string, messageText: string) =>
+      getData(ircTags, key, convertToFlags, messageText),
+    requireFlags: (key: string, messageText: string) =>
+      requireData(ircTags, key, convertToFlags, messageText),
   };
 }

--- a/lib/message/parser/tag-values.ts
+++ b/lib/message/parser/tag-values.ts
@@ -109,7 +109,6 @@ export interface TagValueParser {
   getEmoteSets(key: string): TwitchEmoteSets | undefined;
   requireEmoteSets(key: string): TwitchEmoteSets;
   getFlags(key: string, messageText: string): TwitchFlagList | undefined;
-  requireFlags(key: string, messageText: string): TwitchFlagList;
 }
 
 export function tagParserFor(ircTags: IRCMessageTags): TagValueParser {
@@ -137,7 +136,5 @@ export function tagParserFor(ircTags: IRCMessageTags): TagValueParser {
       requireData(ircTags, key, convertToEmoteSets),
     getFlags: (key: string, messageText: string) =>
       getData(ircTags, key, convertToFlags, messageText),
-    requireFlags: (key: string, messageText: string) =>
-      requireData(ircTags, key, convertToFlags, messageText),
   };
 }

--- a/lib/message/twitch-types/privmsg.ts
+++ b/lib/message/twitch-types/privmsg.ts
@@ -66,8 +66,8 @@ export class PrivmsgMessage extends ChannelIRCMessage
   public readonly emotes: TwitchEmoteList;
   public readonly emotesRaw: string;
 
-  public readonly flags: TwitchFlagList;
-  public readonly flagsRaw: string;
+  public readonly flags: TwitchFlagList | undefined;
+  public readonly flagsRaw: string | undefined;
 
   public readonly messageID: string;
 
@@ -113,8 +113,8 @@ export class PrivmsgMessage extends ChannelIRCMessage
     this.emotes = tagParser.requireEmotes("emotes", this.messageText);
     this.emotesRaw = tagParser.requireString("emotes");
 
-    this.flags = tagParser.requireFlags("flags", this.messageText);
-    this.flagsRaw = tagParser.requireString("flags");
+    this.flags = tagParser.getFlags("flags", this.messageText);
+    this.flagsRaw = tagParser.getString("flags");
 
     this.messageID = tagParser.requireString("id");
 

--- a/lib/message/twitch-types/privmsg.ts
+++ b/lib/message/twitch-types/privmsg.ts
@@ -75,6 +75,12 @@ export class PrivmsgMessage extends ChannelIRCMessage
 
   /**
    * Twitch AutoMod raw flags string.
+   *
+   * If the `flags` tag is missing or of a unparseable format, this will be `undefined`. This is unlike most other
+   * attributes which when missing or malformed will fail the message parsing. However since this attribute is
+   * completely undocumented we cannot rely on the `flags` tag being stable, so this soft fallback is used instead.
+   * In short, ensure your implementation can handle the case where this is `undefined` or is in
+   * a format you don't expect.
    */
   public readonly flagsRaw: string | undefined;
 

--- a/lib/message/twitch-types/privmsg.ts
+++ b/lib/message/twitch-types/privmsg.ts
@@ -1,6 +1,7 @@
 import { TwitchBadgesList } from "../badges";
 import { Color } from "../color";
 import { TwitchEmoteList } from "../emotes";
+import { TwitchFlagList } from "../flags";
 import { ChannelIRCMessage } from "../irc/channel-irc-message";
 import {
   IRCMessage,
@@ -65,6 +66,9 @@ export class PrivmsgMessage extends ChannelIRCMessage
   public readonly emotes: TwitchEmoteList;
   public readonly emotesRaw: string;
 
+  public readonly flags: TwitchFlagList;
+  public readonly flagsRaw: string;
+
   public readonly messageID: string;
 
   public readonly isMod: boolean;
@@ -108,6 +112,9 @@ export class PrivmsgMessage extends ChannelIRCMessage
 
     this.emotes = tagParser.requireEmotes("emotes", this.messageText);
     this.emotesRaw = tagParser.requireString("emotes");
+
+    this.flags = tagParser.requireFlags("flags", this.messageText);
+    this.flagsRaw = tagParser.requireString("flags");
 
     this.messageID = tagParser.requireString("id");
 

--- a/lib/message/twitch-types/privmsg.ts
+++ b/lib/message/twitch-types/privmsg.ts
@@ -69,7 +69,13 @@ export class PrivmsgMessage extends ChannelIRCMessage
   /**
    * Can be an array of Twitch AutoMod flagged words, for use in moderation and/or filtering purposes.
    *
-   * **Note:** This is an undocumented Twitch IRC feature and may change at any time, use at your own risk.
+   * If the `flags` tag is missing or of a unparseable format, this will be `undefined`. This is unlike most other
+   * attributes which when missing or malformed will fail the message parsing. However since this attribute is
+   * completely undocumented we cannot rely on the `flags` tag being stable, so this soft fallback is used instead.
+   * While it will be a major version release if this attribute changes format in dank-twitch-irc, using this is still
+   * at your own risk since it may suddenly contain unexpected data or turn `undefined` one day as
+   * Twitch changes something. In short: **Use at your own risk** and make sure your
+   * implementation can handle the case where this is `undefined`.
    */
   public readonly flags: TwitchFlagList | undefined;
 

--- a/lib/message/twitch-types/privmsg.ts
+++ b/lib/message/twitch-types/privmsg.ts
@@ -66,7 +66,16 @@ export class PrivmsgMessage extends ChannelIRCMessage
   public readonly emotes: TwitchEmoteList;
   public readonly emotesRaw: string;
 
+  /**
+   * Can be an array of Twitch AutoMod flagged words, for use in moderation and/or filtering purposes.
+   *
+   * **Note:** This is an undocumented Twitch IRC feature and may change at any time, use at your own risk.
+   */
   public readonly flags: TwitchFlagList | undefined;
+
+  /**
+   * Twitch AutoMod raw flags string.
+   */
   public readonly flagsRaw: string | undefined;
 
   public readonly messageID: string;

--- a/lib/message/twitch-types/usernotice.ts
+++ b/lib/message/twitch-types/usernotice.ts
@@ -227,7 +227,13 @@ export class UsernoticeMessage extends ChannelIRCMessage {
   /**
    * Can be an array of Twitch AutoMod flagged words, for use in moderation and/or filtering purposes.
    *
-   * **Note:** This is an undocumented Twitch IRC feature and may change at any time, use at your own risk.
+   * If the `flags` tag is missing or of a unparseable format, this will be `undefined`. This is unlike most other
+   * attributes which when missing or malformed will fail the message parsing. However since this attribute is
+   * completely undocumented we cannot rely on the `flags` tag being stable, so this soft fallback is used instead.
+   * While it will be a major version release if this attribute changes format in dank-twitch-irc, using this is still
+   * at your own risk since it may suddenly contain unexpected data or turn `undefined` one day as
+   * Twitch changes something. In short: **Use at your own risk** and make sure your
+   * implementation can handle the case where this is `undefined`.
    */
   public readonly flags: TwitchFlagList | undefined;
 

--- a/lib/message/twitch-types/usernotice.ts
+++ b/lib/message/twitch-types/usernotice.ts
@@ -2,6 +2,7 @@ import camelCase = require("lodash.camelcase");
 import { TwitchBadgesList } from "../badges";
 import { Color } from "../color";
 import { TwitchEmoteList } from "../emotes";
+import { TwitchFlagList } from "../flags";
 import { ChannelIRCMessage } from "../irc/channel-irc-message";
 import { getParameter, IRCMessageData } from "../irc/irc-message";
 import { IRCMessageTags } from "../irc/tags";
@@ -223,6 +224,9 @@ export class UsernoticeMessage extends ChannelIRCMessage {
   public readonly emotes: TwitchEmoteList;
   public readonly emotesRaw: string;
 
+  public readonly flags: TwitchFlagList | undefined;
+  public readonly flagsRaw: string | undefined;
+
   public readonly messageID: string;
 
   public readonly isMod: boolean;
@@ -266,10 +270,13 @@ export class UsernoticeMessage extends ChannelIRCMessage {
 
     if (this.messageText != null) {
       this.emotes = tagParser.requireEmotes("emotes", this.messageText);
+      this.flags = tagParser.getFlags("flags", this.messageText);
     } else {
       this.emotes = [];
     }
     this.emotesRaw = tagParser.requireString("emotes");
+
+    this.flagsRaw = tagParser.getString("flags");
 
     this.messageID = tagParser.requireString("id");
 

--- a/lib/message/twitch-types/usernotice.ts
+++ b/lib/message/twitch-types/usernotice.ts
@@ -224,7 +224,16 @@ export class UsernoticeMessage extends ChannelIRCMessage {
   public readonly emotes: TwitchEmoteList;
   public readonly emotesRaw: string;
 
+  /**
+   * Can be an array of Twitch AutoMod flagged words, for use in moderation and/or filtering purposes.
+   *
+   * **Note:** This is an undocumented Twitch IRC feature and may change at any time, use at your own risk.
+   */
   public readonly flags: TwitchFlagList | undefined;
+
+  /**
+   * Twitch AutoMod raw flags string.
+   */
   public readonly flagsRaw: string | undefined;
 
   public readonly messageID: string;

--- a/lib/message/twitch-types/usernotice.ts
+++ b/lib/message/twitch-types/usernotice.ts
@@ -239,6 +239,12 @@ export class UsernoticeMessage extends ChannelIRCMessage {
 
   /**
    * Twitch AutoMod raw flags string.
+   *
+   * If the `flags` tag is missing or of a unparseable format, this will be `undefined`. This is unlike most other
+   * attributes which when missing or malformed will fail the message parsing. However since this attribute is
+   * completely undocumented we cannot rely on the `flags` tag being stable, so this soft fallback is used instead.
+   * In short, ensure your implementation can handle the case where this is `undefined` or is in
+   * a format you don't expect.
    */
   public readonly flagsRaw: string | undefined;
 


### PR DESCRIPTION
Based on https://github.com/Chatterino/chatterino2/issues/1772.

The `flags` irc tag was recently demystified, but is still undocumented, and there are still some questions regarding what the "score" actually is and the fact that categories and detection seems to not be the same day-after-day. Example\* is that the word `cunt` used to be *(July 1)* assigned 4 categories but testing it out today *(July 10th)* only returns 2 categories.

*Example for that phenomena:
```
[2020-07-1 21:54:48] #supinic supinic: $test cunt
[2020-07-1 21:54:48] #supinic supibot: 6-9:A.5/I.6/P.6/S.6
...
[2020-07-10 02:11:52] #supinic notkarar: $test cunt 󠀀
[2020-07-10 02:11:53] #supinic supibot: Automod score: Identity: 7; Profanity: 7 -- Raw: 6-9:I.7/P.7 󠀀
```
**Therefore the tests are as-is the day they were written, and the hardcoded values if they were to be compared to the values returned by Twitch, after some unknown time, will probably not be the same.**

There also used to exist some strange edge cases regarding links and drug substances where they wouldn't receive a category, but would still have `startIndex` & `endIndex`, I can't seem to repeat that behavior today (Related to above phenomena) but it's been observed:
```
[2020-07-1 22:19:41] #supinic dvh_: $test xanax
[2020-07-1 22:19:43] #supinic supibot: Automod score: -- Raw: 6-10:
```
I've covered that edge case with commit eaa7deb, for now, but I am sure there are better ways of covering it.

Looking forward for **feedback** on this pull request. @RAnders00 