### PR TITLE
Fix edge cases regarding empty category flags

### DIFF
--- a/lib/message/parser/flags.spec.ts
+++ b/lib/message/parser/flags.spec.ts
@@ -120,20 +120,26 @@ describe("./message/parser/flags", function () {
     });
 
     it("should parse single flag, with 3 categories", function () {
-      assert.deepStrictEqual(parseFlags("shut the fuck up", "0-15:A.7/I.6/P.6"), [
-        new TwitchFlag(0, 16, "shut the fuck up", [
-          { category: "A", score: 7 },
-          { category: "I", score: 6 },
-          { category: "P", score: 6 },
-        ]),
-      ]);
+      assert.deepStrictEqual(
+        parseFlags("shut the fuck up", "0-15:A.7/I.6/P.6"),
+        [
+          new TwitchFlag(0, 16, "shut the fuck up", [
+            { category: "A", score: 7 },
+            { category: "I", score: 6 },
+            { category: "P", score: 6 },
+          ]),
+        ]
+      );
     });
 
     it("should parse two flags, but both with empty categories", function () {
-      assert.deepStrictEqual(parseFlags("$test xanax and xanax", "6-10:,16-20:"), [
-        new TwitchFlag(6, 11, "xanax", []),
-        new TwitchFlag(16, 21, "xanax", []),
-      ]);
+      assert.deepStrictEqual(
+        parseFlags("$test xanax and xanax", "6-10:,16-20:"),
+        [
+          new TwitchFlag(6, 11, "xanax", []),
+          new TwitchFlag(16, 21, "xanax", []),
+        ]
+      );
     });
 
     it("should parse six flags, four with multiple categories and two with empty categories", function () {

--- a/lib/message/parser/flags.spec.ts
+++ b/lib/message/parser/flags.spec.ts
@@ -118,5 +118,46 @@ describe("./message/parser/flags", function () {
     it("should parse no flag, in case Twitch changes the functionality", function () {
       assert.deepStrictEqual(parseFlags("stfu", "0-3=PRO.100%"), []);
     });
+
+    it("should parse single flag, with 3 categories", function () {
+      assert.deepStrictEqual(parseFlags("shut the fuck up", "0-15:A.7/I.6/P.6"), [
+        new TwitchFlag(0, 16, "shut the fuck up", [
+          { category: "A", score: 7 },
+          { category: "I", score: 6 },
+          { category: "P", score: 6 },
+        ]),
+      ]);
+    });
+
+    it("should parse two flags, but both with empty categories", function () {
+      assert.deepStrictEqual(parseFlags("$test xanax and xanax", "6-10:,16-20:"), [
+        new TwitchFlag(6, 11, "xanax", []),
+        new TwitchFlag(16, 21, "xanax", []),
+      ]);
+    });
+
+    it("should parse six flags, four with multiple categories and two with empty categories", function () {
+      assert.deepStrictEqual(
+        parseFlags(
+          "shut the fuck up retard streamer you kill a phallic object and xanax and xanax",
+          "0-15:A.7/I.6/P.6,17-22:A.7/I.6,37-40:A.7,44-50:S.7,63-67:,73-77:"
+        ),
+        [
+          new TwitchFlag(0, 16, "shut the fuck up", [
+            { category: "A", score: 7 },
+            { category: "I", score: 6 },
+            { category: "P", score: 6 },
+          ]),
+          new TwitchFlag(17, 23, "retard", [
+            { category: "A", score: 7 },
+            { category: "I", score: 6 },
+          ]),
+          new TwitchFlag(37, 41, "kill", [{ category: "A", score: 7 }]),
+          new TwitchFlag(44, 51, "phallic", [{ category: "S", score: 7 }]),
+          new TwitchFlag(63, 68, "xanax", []),
+          new TwitchFlag(73, 78, "xanax", []),
+        ]
+      );
+    });
   });
 });

--- a/lib/message/parser/flags.spec.ts
+++ b/lib/message/parser/flags.spec.ts
@@ -119,7 +119,7 @@ describe("./message/parser/flags", function () {
       assert.deepStrictEqual(parseFlags("stfu", "0-3=PRO.100%"), []);
     });
 
-    it("should parse single flag, with 3 categories", function () {
+    it("should parse single flag, with three categories", function () {
       assert.deepStrictEqual(
         parseFlags("shut the fuck up", "0-15:A.7/I.6/P.6"),
         [

--- a/lib/message/parser/flags.ts
+++ b/lib/message/parser/flags.ts
@@ -8,7 +8,7 @@ export function parseFlags(
 ): TwitchFlagList {
   const flags: TwitchFlagList = [];
 
-  const regex = /^((?:[0-9]+-[0-9]+:)(?:(?:[ISAP]\.[0-9]+\/?)+,?)?)+$/g;
+  const regex = /^(,?(?:[0-9]+-[0-9]+:)(?:(?:[ISAP]\.[0-9]+\/?)+)?)+$/g;
 
   const matchFlagsSrc = flagsSrc.match(regex);
 


### PR DESCRIPTION
Related to #38.

The current regexp fails when the flags contains more than one flag with no categories, or when (a) flag(s) with no categories is in a collection of flags with categories.

Old regexp coverage: https://regexr.com/590b9
| Value  | Result |
| ------------- | ------------- |
| 6-10:,16-20: | ❌ |
| 0-15:A.7/I.6/P.6,17-22:A.7/I.6,37-40:A.7,44-50:S.7,63-67:,73-77:  | ❌ |

New regexp coverage: https://regexr.com/59094
| Value  | Result |
| ------------- | ------------- |
| 6-10:,16-20: | ✔️ |
| 0-15:A.7/I.6/P.6,17-22:A.7/I.6,37-40:A.7,44-50:S.7,63-67:,73-77:  | ✔️ |

I've also added a test to cover for when there's a single flag with multiple categories. It's a test I missed to add in the initial pull request.
