### PR TITLE
Fix connect method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Bugfix: connect() method now properly resolves if connect() is called on a client that is already `ready`. (#218)
+- Bugfix: `ChatClient#connect()` method now properly resolves if `connect()` is called on a client that is already `ready`. (#218)
 
 ## v4.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unversioned
+
+- Bugfix: connect() method now properly resolves if connect() is called on a client that is already `ready`. (#218)
+
 ## v4.3.0
 
 - Minor: Added `ban` method to `ChatClient` API (#186).

--- a/lib/client/client.ts
+++ b/lib/client/client.ts
@@ -78,7 +78,9 @@ export class ChatClient extends BaseClient {
 
   public async connect(): Promise<void> {
     this.requireConnection();
-    return await new Promise((resolve) => this.on("ready", () => resolve()));
+    if (!this.ready) {
+      await new Promise((resolve) => this.once("ready", () => resolve()));
+    }
   }
 
   public close(): void {

--- a/lib/client/client.ts
+++ b/lib/client/client.ts
@@ -79,7 +79,7 @@ export class ChatClient extends BaseClient {
   public async connect(): Promise<void> {
     this.requireConnection();
     if (!this.ready) {
-      await new Promise((resolve) => this.once("ready", () => resolve()));
+      await new Promise<void>((resolve) => this.once("ready", () => resolve()));
     }
   }
 


### PR DESCRIPTION
Somebody reported to me in twitch chat that calling connect() never resolves if the client is already open. This fixes that. Also fixes usage of on() to once().